### PR TITLE
Fix getMembersWithRole

### DIFF
--- a/src/Client/src/sections/group/staticConfigs.js
+++ b/src/Client/src/sections/group/staticConfigs.js
@@ -214,7 +214,12 @@ module.exports = [
 			]
 		],
 		request: {
-			url: (env, { roleId }) => `https://groups.roblox.com/v1/groups/${env.id}/roles/${roleId}/users`
+			url: (env, { roleId }) => `https://groups.roblox.com/v1/groups/${env.id}/roles/${roleId}/users`,
+			queries: (env, { options = {} }) => ({
+				sortOrder: options.sortOrder || "Desc",
+				limit: options.limit || 100,
+				cursor: options.cursor
+			})
 		},
 		response: (env, params, data) => new env.client.structures.CursorPage({
 			env, params,


### PR DESCRIPTION
A small fix for the getMembersWithRole as it was missing the quaries required for the parameters, causing it to default to the standard 10 individuals per page and stuck on the same cursor.

~Samm#0378