### PR TITLE
Fix/Token refreshing

### DIFF
--- a/src/controllers/Rest/src/token/TokenController.js
+++ b/src/controllers/Rest/src/token/TokenController.js
@@ -5,16 +5,12 @@ class RestTokenController {
 	constructor (client) {
 		this.client = client;
 		this.token = null;
-		this.fetchInterval = null;
-		this.refreshInterval = 5 * 60 * 1000;
 
 		this.refresh = require("./src/refresh").bind(this, this);
 	}
 
 	async fetch () {
-		if (!this.token) {
-			this.token = await this.refresh();
-		}
+		this.token = await this.refresh();
 		return this.token;
 	}
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -694,15 +694,10 @@ class DebugLog {
 class RestTokenController {
     public client: Client;
     public token: string;
-    public fetchInterval: NodeJS.Timer;
 
     constructor(client: Client);
 
     public refresh(): Promise<string>;
-
-    public stop(): void;
-
-    public start(): void;
 }
 
 class CaptchaController {


### PR DESCRIPTION
The TokenController now refreshes its token on every fetch instead of only once. I've removed the start and stop methods from the typings as they sound like they belong to the interval properties.

This PR resolves #19 