### PR TITLE
Fix/Don't throw HTTP errors on token validation errors

### DIFF
--- a/src/controllers/Rest/src/token/src/refresh.js
+++ b/src/controllers/Rest/src/token/src/refresh.js
@@ -24,7 +24,7 @@ module.exports = async controller => {
 					}
 				},
 				data: e
-			}
+			};
 
 			const [success] = tokenResponseHandler(response);
 			if (!success) {

--- a/src/controllers/Rest/src/token/src/refresh.js
+++ b/src/controllers/Rest/src/token/src/refresh.js
@@ -27,11 +27,10 @@ module.exports = async controller => {
 			}
 
 			const [success] = tokenResponseHandler(response);
-			if (success) {
-				return [true, response];
-			} else {
+			if (!success) {
 				throw new Error(e);
 			}
+			return [true, response];
 		}
 
 		controller.client.debug.log(`An error occurred while processing the TokenController.refresh function`);

--- a/src/controllers/Rest/src/token/src/refresh.js
+++ b/src/controllers/Rest/src/token/src/refresh.js
@@ -1,3 +1,5 @@
+const tokenResponseHandler = require("../../../lib/responseHandlers/token");
+
 /**
  * @param {RestTokenController} controller The Rest controller
  */
@@ -14,6 +16,24 @@ module.exports = async controller => {
 			token: true
 		}
 	}).then(r => [true, r]).catch(e => {
+		if (controller.client.options.setup.throwHttpErrors) {
+			const response = {
+				options: {
+					disabledChecks: {
+						token: true
+					}
+				},
+				data: e
+			}
+
+			const [success] = tokenResponseHandler(response);
+			if (success) {
+				return [true, response];
+			} else {
+				throw new Error(e);
+			}
+		}
+
 		controller.client.debug.log(`An error occurred while processing the TokenController.refresh function`);
 		return [false, e];
 	});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -734,6 +734,7 @@ interface ClientConstructorOptions {
         },
         requester: Function; // TOOD: For dealing with the requests
         debugging: boolean;
+        throwHttpErrors: boolean;
     }
 }
 


### PR DESCRIPTION
My last PR (https://github.com/Visualizememe/bloxy/pull/18) implemented the ability to set got's throwHttpErrors setting to true. This however introduced a problem because when an X-CSRF token is fetched from Roblox, a HTTP 403 is guaranteed which is "desired" in that case. 

This PR implements a check that throws when an error is not desired and passes when it is (403), so the controller can continue reading the token.

It's not a very elegant way of fixing this but I tried my best to use already existing code (like the token responseHandler).