### PR TITLE
Fix/Initialize missing group fields

### DIFF
--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -671,7 +671,7 @@ export interface GroupOptions {
     memberCount: number;
     isBuildersClubOnly: boolean;
     publicEntryAllowed: boolean;
-    created?: string;
+    isLocked: boolean;
 }
 
 
@@ -680,6 +680,10 @@ export class Group extends GroupBase {
     public name: string;
     public owner: GroupMember | null;
     public shout: GroupShout | null;
+    public memberCount: number;
+    public isBuildersClubOnly: boolean;
+    public publicEntryAllowed: boolean;
+    public isLocked: boolean;
 
     constructor (data: GroupOptions, client: Client) {
         super(data, client);
@@ -701,6 +705,10 @@ export class Group extends GroupBase {
                 name: this.name || undefined
             }
         }, client) : null;
+        this.memberCount = data.memberCount;
+        this.isBuildersClubOnly = data.isBuildersClubOnly;
+        this.publicEntryAllowed = data.publicEntryAllowed;
+        this.isLocked = data.isLocked;
     }
 }
 


### PR DESCRIPTION
Not all group data was initialized in the Group constructor. This PR initializes all the missing group data (got the fields from the GetGroup type in GroupsAPI).

I also removed the created field as it wasn't used and the Roblox API doesn't return it. If you want that back, let me know. 