### PR TITLE
Feature/XCSRF refresh interval option

### DIFF
--- a/src/controllers/rest/RESTController.ts
+++ b/src/controllers/rest/RESTController.ts
@@ -91,7 +91,7 @@ class RESTController {
     }
 
     /**
-     * Gets the existing xcsrf token if it's not more than 5 minutes old,
+     * Gets the existing XCSRF token if it's not older than set refresh interval,
      * otherwise, fetch a new one
      */
     async getXCSRFToken (): Promise<string | undefined> {

--- a/src/controllers/rest/RESTController.ts
+++ b/src/controllers/rest/RESTController.ts
@@ -95,7 +95,7 @@ class RESTController {
      * otherwise, fetch a new one
      */
     async getXCSRFToken (): Promise<string | undefined> {
-        if (!this.options.xcsrf || (Date.now() - (this.options.xcsrfSet || 0)) >= (5 * 60 * 1000)) {
+        if (!this.options.xcsrf || (Date.now() - (this.options.xcsrfSet || 0)) >= (this.options.xcsrfRefreshInterval || DefaultRESTControllerOptions.xcsrfRefreshInterval)) {
             // Refresh token
             await this.fetchXCSRFToken().then(token => {
                 this.setXCSRFToken(token);
@@ -183,6 +183,22 @@ class RESTController {
      */
     getUserAgent (): string | undefined {
         return this.options.userAgent;
+    }
+
+    /**
+     * Sets the XCSRF token refresh interval
+     * @param {number} xcsrfRefreshInterval The time in ms to use
+     */
+    setXCSRFTokenRefreshInterval (xcsrfRefreshInterval: number): void {
+        this.options.xcsrfRefreshInterval = xcsrfRefreshInterval;
+    }
+
+    /**
+     * Gets the XCSRF token refresh interval
+     * @returns {number | undefined}
+     */
+    getXCSRFTokenRefreshInterval (): number | undefined {
+        return this.options.xcsrfRefreshInterval;
     }
 
     /**

--- a/src/interfaces/RESTInterfaces.ts
+++ b/src/interfaces/RESTInterfaces.ts
@@ -25,6 +25,10 @@ export declare type RESTControllerOptions = {
      * The time in ms when the xcsrf was last set
      */
     xcsrfSet?: number;
+    /**
+     * Refresh interval in ms for XCSRF token updating
+     */
+    xcsrfRefreshInterval?: number;
 };
 
 export declare type RESTCreateCookieOptions = {
@@ -146,5 +150,6 @@ export const DefaultRESTControllerOptions = {
     userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
     proxy: undefined,
     xcsrf: undefined,
-    xcsrfSet: undefined
+    xcsrfSet: undefined,
+    xcsrfRefreshInterval: 5 * 60 * 1000
 };


### PR DESCRIPTION
This PR gives the library user the ability to set the RESTController's XCSRF token refresh interval.
It defaults to 5 minutes.

This PR resolves #113, once this is merged I can set the interval to 0 and have it always fetch new tokens.