### PR TITLE
Refresh XCSRF on Token Validation errors

### DIFF
--- a/src/controllers/rest/RESTController.ts
+++ b/src/controllers/rest/RESTController.ts
@@ -202,6 +202,24 @@ class RESTController {
     }
 
     /**
+     * Sets the amount of retries to be made to refresh XCSRF
+     * tokens on Token Validation errors
+     * @param {number} xcsrfRefreshMaxRetries Number of retries
+     */
+    setXCSRFTokenRefreshMaxRetries (xcsrfRefreshMaxRetries: number): void {
+        this.options.xcsrfRefreshMaxRetries = xcsrfRefreshMaxRetries;
+    }
+
+    /**
+     * Gets the amount of retries to be made to refresh XCSRF
+     * tokens on Token Validation errors
+     * @returns {number | undefined}
+     */
+    getXCSRFTokenRefreshMaxRetries (): number | undefined {
+        return this.options.xcsrfRefreshMaxRetries;
+    }
+
+    /**
      * Sets the options for the RESTController
      * @param {RESTControllerOptions} options The options to use
      * @returns {RESTControllerOptions}

--- a/src/controllers/rest/lib/updateXCSRFToken.ts
+++ b/src/controllers/rest/lib/updateXCSRFToken.ts
@@ -7,6 +7,9 @@ export default function updateXCSRFToken (restController: RESTController): Promi
         xcsrf: false,
         checks: {
             xcsrf: false
+        },
+        responseOptions: {
+            allowedStatusCodes: [403]
         }
     }).then(response => {
         const foundXcsrfToken = response.headers["x-csrf-token"];

--- a/src/controllers/rest/request/RESTRequest.ts
+++ b/src/controllers/rest/request/RESTRequest.ts
@@ -16,9 +16,15 @@ class RESTRequest {
      */
     public requestOptions: RESTRequestOptions;
 
+    /**
+     * The amount of attempts to execute this request
+     */
+    public attempts: number;
+
     constructor (controller: RESTController, options: RESTRequestOptions) {
         this.controller = controller;
         this.requestOptions = options;
+        this.attempts = 0;
     }
 
     setOptions (options: RESTRequestOptions): RESTRequestOptions {
@@ -34,6 +40,8 @@ class RESTRequest {
 
         // Console.log(this.requestOptions);
         const responseData = await this.controller.requester(this.requestOptions);
+        this.attempts++;
+
         const response = new RESTResponse(this.controller, this, responseData);
         return response.process();
     }

--- a/src/controllers/rest/request/RESTRequest.ts
+++ b/src/controllers/rest/request/RESTRequest.ts
@@ -17,7 +17,7 @@ class RESTRequest {
     public requestOptions: RESTRequestOptions;
 
     /**
-     * The amount of attempts to execute this request
+     * The amount of times this request has been executed
      */
     public attempts: number;
 

--- a/src/controllers/rest/response/RESTResponse.ts
+++ b/src/controllers/rest/response/RESTResponse.ts
@@ -1,5 +1,6 @@
 import RESTController from "../RESTController";
 import RESTRequest from "../request";
+import { BloxyHttpError } from "../../../util/errors/errors";
 import { RESTResponseDataType } from "../../../interfaces/RESTInterfaces";
 
 
@@ -17,13 +18,27 @@ export default class RESTResponse {
         this.responseData.status = responseData.status;
     }
 
-    process (): RESTResponseDataType {
+    async process (): Promise<RESTResponseDataType> {
         const allProcessed = this.controller.responseHandlers.map(handler => handler(this));
 
         if (allProcessed.every(processed => processed === true)) {
             return this.responseData;
         } else {
-            throw allProcessed.find(processed => processed instanceof Error);
+            const error = allProcessed.find(processed => processed instanceof Error);
+
+            if (error && error instanceof BloxyHttpError) {
+                if (error.name === "BloxyHttpInvalidStatusCodeError" && error.statusCode === 403) {
+                    // 1 attempt = 0 retries
+                    if (this.request.attempts - 1 === this.controller.getXCSRFTokenRefreshMaxRetries()) {
+                        throw error;
+                    } else {
+                        await this.controller.fetchXCSRFToken();
+                        return this.request.send();
+                    }
+                }
+            }
+
+            throw error;
         }
     }
 }

--- a/src/interfaces/RESTInterfaces.ts
+++ b/src/interfaces/RESTInterfaces.ts
@@ -29,6 +29,11 @@ export declare type RESTControllerOptions = {
      * Refresh interval in ms for XCSRF token updating
      */
     xcsrfRefreshInterval?: number;
+    /**
+     * The amount of retries to be made to refresh XCSRF
+     * tokens on Token Validation errors
+     */
+    xcsrfRefreshMaxRetries?: number;
 };
 
 export declare type RESTCreateCookieOptions = {
@@ -151,5 +156,6 @@ export const DefaultRESTControllerOptions = {
     proxy: undefined,
     xcsrf: undefined,
     xcsrfSet: undefined,
-    xcsrfRefreshInterval: 5 * 60 * 1000
+    xcsrfRefreshInterval: 5 * 60 * 1000,
+    xcsrfRefreshMaxRetries: 4
 };


### PR DESCRIPTION
Hi, I'm back :)

Since my last [PR](https://github.com/Visualizememe/bloxy/pull/115) the amount of token validation errors I get has decreased, but they sadly haven't fully disappeared yet.
![image](https://user-images.githubusercontent.com/35309288/98488981-60086380-222c-11eb-8229-5346d2d87e17.png)

In this PR I implemented the refreshing of XCSRF tokens on Token Validation errors. It will attempt to execute a request a max amount of 5 times (customizable); the first time and then 4 retries. If after the 5th attempt it still errors, RESTResponse.process will throw the original error returned by the handlers.

I know about the other existing [PR](https://github.com/Visualizememe/bloxy/pull/117). My PR does, however, implement a max retries option and keeps the request/response handlers' typings unchanged (which seemed desirable).